### PR TITLE
Game and mod folder picker

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -9,8 +9,11 @@ const rootPath =
         ? vscode.workspace.workspaceFolders[0].uri.fsPath
         : "";
 
-const doc_api_link = // TODO: Fetch latest version from a config so we arent modifying code for API version bumps
-    "\n\n[View in lua_api.md](https://github.com/luanti-org/luanti/blob/5.11.0/doc/lua_api.md?plain=1#";
+const docApiUrl = vscode.workspace
+    .getConfiguration("minetest-tools")
+    .get("docApiUrl");
+
+const doc_api_link = `\n\n[View in lua_api.md](${docApiUrl})`;
 const luacheckrc = `read_globals = {
     "DIR_DELIM", "INIT",
 
@@ -101,7 +104,7 @@ async function pickGameFolder() {
             return undefined;
         }
 
-        gameFolder = path.relative(rootPath, pickedFolder[0].path);
+        gameFolder = path.relative(rootPath, pickedFolder[0].fsPath);
     }
     else {
         gameFolder = pickedFolderOption.value;
@@ -302,12 +305,12 @@ function activate(context) {
 
             // pick game folder
             gameFolder = await pickGameFolder();
-            if (!gameFolder) {
+            if (gameFolder === undefined) {
                 return;
             }
             
             // Input game name of folder is not the root
-            if (gameFolder) {
+            if (gameFolder !== "") {
                 gameName = await vscode.window.showInputBox({
                     prompt: "Enter name of the game",
                     value: "",
@@ -317,7 +320,7 @@ function activate(context) {
                     return;
                 }
 
-                gameFolder = path.join('games',gameName);
+                gameFolder = path.join(gameFolder,gameName);
             }
 
             // create game files

--- a/extension.js
+++ b/extension.js
@@ -250,11 +250,11 @@ function activate(context) {
             let modFolder = '';
 
             modFolder = await pickModFolder();
-            if (!modFolder) {
+            if (modFolder === undefined) {
                 return;
             }
 
-            if (modFolder) {
+            if (modFolder !== "") {
                 modName = await vscode.window.showInputBox({
                     prompt: "Enter name of the mod",
                     value: "",

--- a/extension.js
+++ b/extension.js
@@ -1,12 +1,15 @@
 const vscode = require("vscode");
 const fs = require("fs");
 const path = require("path");
+const child_process = require('child_process');
 const snippets = require("./smartsnippets.json");
 
 const rootPath =
     vscode.workspace.workspaceFolders != undefined
         ? vscode.workspace.workspaceFolders[0].uri.fsPath
         : "";
+
+const luantiExeFilePath = path.join(rootPath, 'bin', 'luanti.exe');        
 const doc_api_link = // TODO: Fetch latest version from a config so we arent modifying code for API version bumps
     "\n\n[View in lua_api.md](https://github.com/luanti-org/luanti/blob/5.11.0/doc/lua_api.md?plain=1#";
 const luacheckrc = `read_globals = {
@@ -71,8 +74,7 @@ function makeFiles(files, folders, subfolder = '') {
 }
 
 function isLuantiGameRoot() {
-    // TODO: other check required for non windows
-    var luantiExeFilePath = path.join(rootPath, 'bin', 'luanti.exe');
+    // TODO: other check required for non windows    
     return fs.existsSync(luantiExeFilePath);
 }
 
@@ -281,6 +283,27 @@ function activate(context) {
                     ? "Luanti Intellisense active in workspace only."
                     : "Luanti Intellisense active for all Lua files.",
             );
+        },
+    );
+
+    // Start Luanti game
+    let startLuantiGame = vscode.commands.registerCommand(
+        "extension.startLuantiGame",
+        () => {
+            if(isLuantiGameRoot()) {
+                vscode.window.showInformationMessage('starting luanti game');
+
+                // TODO: other file for non windows
+                child_process.execFile(luantiExeFilePath, null, (error, stdout, stderr) => {
+                    if (error) {
+                        vscode.window.showErrorMessage(`Error: ${error.message}`);
+                        return;
+                    }
+                });
+            }
+            else {
+                vscode.window.showErrorMessage('Could not find luanti executable');
+            }
         },
     );
 

--- a/extension.js
+++ b/extension.js
@@ -79,6 +79,44 @@ function isLuantiGameRoot() {
     return fs.existsSync(luantiExeFilePath);
 }
 
+async function pickGameFolder() {
+    let gameFolder = '';
+    const folderOptions = [
+        { label: "Root folder ('/')", value: "" },
+        { label: "Games folder ('/games')", value: "/games" },
+        { label: "Pick other folder", value: "other" }
+    ];
+
+    const pickedFolderOption = await vscode.window.showQuickPick( folderOptions, {title: 'Where do you want to create the game'});
+
+    if (!pickedFolderOption)
+    {
+        return undefined;
+    }
+
+    if (pickedFolderOption.value === 'other') {
+        // pick other folder
+        const options = {
+            canSelectMany: false,
+            openLabel: 'Select',
+            canSelectFiles: false,
+            canSelectFolders: true
+        };
+
+        const pickedFolder = await vscode.window.showOpenDialog(options);
+        if (!pickedFolder || pickedFolder.length < 1) {
+            return undefined;
+        }
+
+        gameFolder = pickedFolder[0].path;
+    }
+    else {
+        gameFolder = pickedFolderOption.value;
+    }
+
+    return gameFolder;
+}
+
 function getGameFolders() {
     var gamesFilePath = path.join(rootPath, "games");
     if (fs.existsSync(gamesFilePath))
@@ -221,37 +259,9 @@ function activate(context) {
             let gameFolder = '';
 
             // pick game folder
-            const folderOptions = [
-                { label: "Root folder ('/')", value: "" },
-                { label: "Games folder ('/games')", value: "/games" },
-                { label: "Pick other folder", value: "other" }
-            ]
-
-            const pickedFolderOption = await vscode.window.showQuickPick( folderOptions, {title: 'Where do you want to create the game'})
-
-            if (!pickedFolderOption)
-            {
+            gameFolder = await pickGameFolder();
+            if (!gameFolder) {
                 return;
-            }
-
-            if (pickedFolderOption.value === 'other') {
-                // pick other folder
-                const options = {
-                    canSelectMany: false,
-                    openLabel: 'Select',
-                    canSelectFiles: false,
-                    canSelectFolders: true
-                };
-        
-                const pickedFolder = await vscode.window.showOpenDialog(options);
-                if (!pickedFolder || pickedFolder.length < 1) {
-                    return
-                }
-
-                gameFolder = pickedFolder[0].path;
-            }
-            else {
-                gameFolder = pickedFolderOption.value;
             }
             
             // Input game name of folder is not the root

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Luanti Tools (formerly Minetest Tools)",
     "description": "Useful tools for Luanti developers.",
     "icon": "icon.png",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "author": {
         "name": "GreenXenith"
     },

--- a/package.json
+++ b/package.json
@@ -75,6 +75,10 @@
                         "type": "boolean",
                         "default": true,
                         "description": "Code snippets will only be shown if certain files (init.lua, mods, modpack.txt) are detected in the main workspace folder."
+                    },
+                    "minetest-tools.gameExecutablePath": {
+                        "type": "string",
+                        "description": "Path to the Lunati game executable. Used for starting the game with the 'Start Luanti game' command."
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
             {
                 "command": "extension.workspaceToggle",
                 "title": "Luanti Tools: Toggle Workspace Intellisense"
+            },
+            {
+                "command": "extension.startLuantiGame",
+                "title": "Luanti Tools: Start Luanti game"
             }
         ],
         "configuration": [

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
                     "minetest-tools.gameExecutablePath": {
                         "type": "string",
                         "description": "Path to the Lunati game executable. Used for starting the game with the 'Start Luanti game' command."
+                    },
+                    "minetest-tools.docApiUrl": {
+                        "type": "string",
+                        "description": "Url to the luanti documentation api",
+                        "default":"https://github.com/luanti-org/luanti/blob/5.15.1/doc/lua_api.md?plain=1#"
                     }
                 }
             }


### PR DESCRIPTION
- When creating a new Game project it gives the option to select where to add the project:
  -  Root folder
  - '/games' folder
  - Pick an other directory with the showOpenDialog function
- When creating a new Mod project it gives the option to select where to add the project:
  -  Root folder
  - '/mods' folder
  -  '/mods' folder for games in the '/games' folder
  - Pick an other directory with the showOpenDialog function
 - Added a command to start the luanti game from vscode
 - Moved the documentation api link to a setting

